### PR TITLE
pins numpy as 2.0.3 not working

### DIFF
--- a/LinearModel/requirements.txt
+++ b/LinearModel/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy==1.23.3
 protobuf==3.20.2
 scikit-learn

--- a/LinearRegression/requirements.txt
+++ b/LinearRegression/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy==1.23.3
 protobuf==3.20.2
 scikit-learn

--- a/LogisticRegression/requirements.txt
+++ b/LogisticRegression/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy==1.23.3
 protobuf==3.20.2
 scikit-learn

--- a/Ridge/requirements.txt
+++ b/Ridge/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy==1.23.3
 protobuf==3.20.2
 scikit-learn

--- a/RidgeCV/requirements.txt
+++ b/RidgeCV/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy==1.23.3
 protobuf==3.20.2
 scikit-learn

--- a/RidgeClassifier/requirements.txt
+++ b/RidgeClassifier/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy==1.23.3
 protobuf==3.20.2
 scikit-learn

--- a/RidgeClassifierCV/requirements.txt
+++ b/RidgeClassifierCV/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy==1.23.3
 protobuf==3.20.2
 scikit-learn


### PR DESCRIPTION
Tried to run the logistic regression block locally today the block installed with numpy 2.0.3 and that broke the jax conversion part with the following error:

```python
Loading pickle model...
Traceback (most recent call last):
  File "/app/convert_model.py", line 63, in <module>
    clf = pickle.load(f)
ModuleNotFoundError: No module named 'numpy._core'
Return code was not 0, but 1
```

Pinning to numpy==1.23.3 (which matches the numpy used in the jax conversion container) fixes the issue.